### PR TITLE
Leaderboards between questions

### DIFF
--- a/app/api/question_page.py
+++ b/app/api/question_page.py
@@ -17,14 +17,20 @@ def question():
     question_num = rooms[room]["question_index"]
     if question_num >= len(QUIZ["questions"]):
         # redirect to scoreboard/end of game results!
-        print(rooms[room]["usernames"])
-        user_scores = {name: data["score"] for name, data in rooms[room]["usernames"].items()}
-        user_scores_sorted = sorted(user_scores.items(), key=lambda kv: (kv[1], kv[0]), reverse=True)
 
-        return render_template("game/leaderboard.html", user_scores=user_scores_sorted)
+        return redirect(url_for('question_page.leaderboard'))
 
     return render_template(
         "game/question_page.html",
         quiz_title=QUIZ["title"],
         question=QUIZ["questions"][question_num],
     )
+
+
+@question_page.route("/leaderboard", methods=["POST", "GET"])
+def leaderboard():
+    room = session.get("room", None)
+    print(rooms[room]["usernames"])
+    user_scores = {name: data["score"] for name, data in rooms[room]["usernames"].items()}
+    user_scores_sorted = sorted(user_scores.items(), key=lambda kv: (kv[1], kv[0]), reverse=True)
+    return render_template("game/leaderboard.html", user_scores=user_scores_sorted)

--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -25,7 +25,7 @@ def next_question(socketio, room):
     if rooms[room]["question_index"] < len(QUIZ["questions"]):
         rooms[room]["timer_started"] = False
         rooms[room]["question_index"] += 1
-        socketio.emit("next_question", to=room)
+        socketio.emit("leaderboard", to=room)
 
 
 def start_question_timer(socketio, room):
@@ -42,12 +42,12 @@ def start_question_timer(socketio, room):
     )  # change to post-question leaderboard page
 
 
-def leaderscore(socketio, room):
+def leaderboard(socketio, room):
     rooms[room]["timer_started"] = False
     # if no more questions then signal browser to redirect to landing page instead of next question.
     if rooms[room]["question_index"] == len(QUIZ["questions"]):
         socketio.emit("landing_page", to=room)
-    socketio.emit("leaderscore", to=room)
+    socketio.emit("next_question", to=room)
 
 
 def leaderboard_timer(socketio, room):
@@ -57,7 +57,7 @@ def leaderboard_timer(socketio, room):
         timer -= 1
         socketio.emit("countdown", timer, to=room)
     eventlet.spawn(
-        leaderscore, socketio, room
+        leaderboard, socketio, room
     )
 
 

--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -42,20 +42,22 @@ def start_question_timer(socketio, room):
     )  # change to post-question leaderboard page
 
 
-def landing_page(socketio, room):
-    print('landing_page')
-    socketio.emit("landing_page", to=room)
+def leaderscore(socketio, room):
+    rooms[room]["timer_started"] = False
+    # if no more questions then signal browser to redirect to landing page instead of next question.
+    if rooms[room]["question_index"] == len(QUIZ["questions"]):
+        socketio.emit("landing_page", to=room)
+    socketio.emit("leaderscore", to=room)
 
 
 def leaderboard_timer(socketio, room):
-    timer = 10
+    timer = 5
     while timer:
-        print(timer)
         eventlet.sleep(1)
         timer -= 1
         socketio.emit("countdown", timer, to=room)
     eventlet.spawn(
-        landing_page, socketio, room
+        leaderscore, socketio, room
     )
 
 

--- a/app/templates/game/leaderboard.html
+++ b/app/templates/game/leaderboard.html
@@ -7,7 +7,7 @@
 {% block container %}
 
 <body>
-    <h4 class="question-timer">10</h4>
+    <h4 class="question-timer">5</h4>
     <div class="container mt-5" align="center">
         <h1 class="mb-4">Quiz Leaderboard</h1>
         <table class="table table-striped">
@@ -31,7 +31,7 @@
     let socket = io();
     socket.emit("leaderboard_connect");
 
-    socket.on('leaderscore', () => {
+    socket.on('next_question', () => {
         window.location.href =  {{ url_for('question_page.question') }}
     });
 

--- a/app/templates/game/leaderboard.html
+++ b/app/templates/game/leaderboard.html
@@ -31,8 +31,12 @@
     let socket = io();
     socket.emit("leaderboard_connect");
 
-    socket.on('landing_page', () => {
+    socket.on('leaderscore', () => {
         window.location.href =  {{ url_for('question_page.question') }}
+    });
+
+    socket.on('landing_page', () => {
+        window.location.href =  '/'
     });
 
     socket.on('countdown', (data) => {

--- a/app/templates/game/leaderboard.html
+++ b/app/templates/game/leaderboard.html
@@ -32,7 +32,7 @@
     socket.emit("leaderboard_connect");
 
     socket.on('landing_page', () => {
-        window.location.href =  '/'
+        window.location.href =  {{ url_for('question_page.question') }}
     });
 
     socket.on('countdown', (data) => {

--- a/app/templates/game/question_page.html
+++ b/app/templates/game/question_page.html
@@ -53,7 +53,7 @@
         clickedBtn.click()
     })
 
-    socket.on('next_question', () => {
+    socket.on('leaderboard', () => {
         window.location.href = '/questionpage/leaderboard'
     })
 

--- a/app/templates/game/question_page.html
+++ b/app/templates/game/question_page.html
@@ -54,7 +54,7 @@
     })
 
     socket.on('next_question', () => {
-        window.location.href = {{ url_for('question_page.question') }}
+        window.location.href = '/questionpage/leaderboard'
     })
 
     socket.on('countdown', (data) => {


### PR DESCRIPTION
This pull requests introduces a few lines necessary for a working version of the code Celina and I previously worked on to allow the leader board to appear between questions.

Mainly, the pull request takes care of resetting the timer_started flag to false before calling the next question because otherwise the timer won't work for question rounds beyond the first question page.