### PR TITLE
Docker

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,0 +1,28 @@
+# Use an official Nginx runtimae as the base image
+FROM docker.io/python:3.10
+
+# Update the package list and install Git
+RUN apt update && apt install -y git
+
+# Install Python, pip3
+RUN apt install -y python3
+RUN apt install -y pip
+
+# Create a directory for your project
+WORKDIR /root/production
+
+# Clone the Quiz app repo into the container
+RUN git clone https://github.com/christopher-ga/recurse-quiz-app.git
+
+# Change to the local repo
+WORKDIR /root/production/recurse-quiz-app
+
+# Install (systemwide) the packages necessary for the Flask quiz app to run
+RUN apt install -y gunicorn python3-gunicorn python3-eventlet python3-dotenv python3-flask python3-flask-migrate python3-flask-socketio
+
+# Copy custom start up script that runs nginx and the flask app
+COPY start_quiz.sh /root/production/recurse-quiz-app/start_quiz.sh
+RUN chmod u+x /root/production/recurse-quiz-app/start_quiz.sh
+
+# Run the quiz Flask app
+CMD ["/root/production/recurse-quiz-app/start_quiz.sh"]

--- a/docker/app/start_quiz.sh
+++ b/docker/app/start_quiz.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Generate random secret key
+echo SECRET_KEY=$(echo $RANDOM | sha256sum |head -c 64) > .env
+
+# Run the quiz app
+gunicorn -k eventlet -b 0.0.0.0:8000 wsgi:app

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,12 +2,14 @@ version: '3'
 services:
   nginx:
     image: docker.io/nginx:latest
+    container_name: docker-nginx-1
     ports:
       - "80:80"
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
 
   quiz-app:
+    container_name: docker-quiz-app-1
     build:
       context: ./app
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  nginx:
+    image: docker.io/nginx:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+
+  quiz-app:
+    build:
+      context: ./app
+    ports:
+      - "8000:8000"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass http://docker_quiz-app_1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Prefix /;
+        proxy_read_timeout 3600s;  # Adjust as needed
+        proxy_send_timeout 3600s;  # Adjust as needed
+    }
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -3,7 +3,7 @@ server {
     server_name _;
 
     location / {
-        proxy_pass http://docker_quiz-app_1:8000;
+        proxy_pass http://docker-quiz-app-1:8000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
This pull request adds Docker and Docker-Compose configuration files that allow the Quiz Web App to run as containerized processes.
 
Following recommended practices, I split the app into two containers, one hosting the Nginx reverse proxy server that listens on standard HTTP port 80, and the other running the quiz app code listening on port 8000. The Nginx container is setup to communicate with the quiz app container, which it expects on port 8000.

You should be able to build and run the containers by installing docker and docker-compose on your local computer, or on a remote server (I tested it on AWS) as long as you can install Docker on that. Until it's merged into main, you'll have to checkout the "docker" branch, change into the docker directory `cd docker`, and run `sudo docker-compose up` to start the quiz app.  Once the containers are running, you can navigate your browser to the IP address of that computer.

If you get a chance to test it, please let me know how it's working for you. 